### PR TITLE
Use lastest ex_hash_ring

### DIFF
--- a/lib/redlock/node_chooser/store/hash_ring.ex
+++ b/lib/redlock/node_chooser/store/hash_ring.ex
@@ -1,4 +1,5 @@
 defmodule Redlock.NodeChooser.Store.HashRing do
+  alias ExHashRing.HashRing
 
   @behaviour Redlock.NodeChooser.Store
   require Logger

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Redlock.Mixfile do
       {:redix, ">= 0.6.1"},
       {:poolboy, "~> 1.5"},
       {:fastglobal, "~> 1.0.0"},
-      {:ex_hash_ring, "~> 1.0"},
+      {:ex_hash_ring, "~> 3.0"},
       {:secure_random, "~> 0.5.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "ex_hash_ring": {:hex, :ex_hash_ring, "1.0.0", "9eb081ecac43435937b0a00db08477071f4183a137db28700b06fe424d0e4c8f", [:mix], [], "hexpm"},
+  "ex_hash_ring": {:hex, :ex_hash_ring, "3.0.0", "da32c83d7c6d964b9537eb52f27bad0a3a6f7012efdc2749e11a5f268b120b6b", [:mix], [], "hexpm"},
   "fastglobal": {:hex, :fastglobal, "1.0.0", "f3133a0cda8e9408aac7281ec579c4b4a8386ce0e99ca55f746b9f58192f455b", [:mix], [], "hexpm"},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
   "redix": {:hex, :redix, "0.7.1", "25a6c1c0d9b2d12a35aef759f9e49bd9bca00e0cd857ce766412f08fdda72163", [:mix], [{:connection, "~> 1.0", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
It was discovered that `libring` and `ex_hash_ring` had conflicting modules
names which caused issues for a user that ended up with both through transitive
dependencies.

https://github.com/discordapp/ex_hash_ring/issues/3
https://github.com/bitwalker/libring/issues/15

This diff bumps you to the latest version of `ex_hash_ring` which now
has a namespace to avoid conflict.