### PR TITLE
Support specifying database

### DIFF
--- a/lib/redlock/connection_keeper.ex
+++ b/lib/redlock/connection_keeper.ex
@@ -1,6 +1,7 @@
 defmodule Redlock.ConnectionKeeper do
 
   @default_port 6379
+  @default_database nil
   @default_reconnection_interval_base 500
   @default_reconnection_interval_max  5_000
 
@@ -15,6 +16,7 @@ defmodule Redlock.ConnectionKeeper do
 
   defstruct host: "",
             port: nil,
+            database: nil,
             redix: nil,
             auth: nil,
             reconnection_interval_base: 0,
@@ -31,8 +33,8 @@ defmodule Redlock.ConnectionKeeper do
     {:ok, new(opts)}
   end
 
-  def handle_info(:connect, %{host: host, port: port, reconnection_attempts: attempts}=state) do
-    case Redix.start_link([host: host, port: port],
+  def handle_info(:connect, %{host: host, port: port, database: database, reconnection_attempts: attempts}=state) do
+    case Redix.start_link([host: host, port: port, database: database],
                           [sync_connect: true, exit_on_disconnection: true]) do
       {:ok, pid} ->
         if FastGlobal.get(:redlock_conf).show_debug_logs do
@@ -80,6 +82,7 @@ defmodule Redlock.ConnectionKeeper do
 
     host = Keyword.fetch!(opts, :host)
     port = Keyword.get(opts, :port, @default_port)
+    database = Keyword.get(opts, :database, @default_database)
     auth = Keyword.get(opts, :auth)
 
     reconnection_interval_base =
@@ -95,6 +98,7 @@ defmodule Redlock.ConnectionKeeper do
     %__MODULE__{
       host:                       host,
       port:                       port,
+      database:                   database,
       auth:                       auth,
       redix:                      nil,
       reconnection_attempts:      0,

--- a/lib/redlock/node_supervisor.ex
+++ b/lib/redlock/node_supervisor.ex
@@ -13,21 +13,23 @@ defmodule Redlock.NodeSupervisor do
     name          = Keyword.fetch!(opts, :pool_name)
     host          = Keyword.fetch!(opts, :host)
     port          = Keyword.fetch!(opts, :port)
+    database      = Keyword.fetch!(opts, :database)
     auth          = Keyword.fetch!(opts, :auth)
     interval_base = Keyword.fetch!(opts, :reconnection_interval_base)
     interval_max  = Keyword.fetch!(opts, :reconnection_interval_max)
     size          = Keyword.fetch!(opts, :pool_size)
 
-    children(name, host, port, auth, interval_base, interval_max, size)
+    children(name, host, port, database, auth, interval_base, interval_max, size)
     |> Supervisor.init(strategy: :one_for_one)
 
   end
 
-  defp children(name, host, port, auth, interval_base, interval_max, size) do
+  defp children(name, host, port, database, auth, interval_base, interval_max, size) do
     [:poolboy.child_spec(name,
                          pool_opts(name, size),
                          [host: host,
                           port: port,
+                          database: database,
                           auth: auth,
                           reconnection_interval_base: interval_base,
                           reconnection_interval_max:  interval_max])]

--- a/lib/redlock/supervisor.ex
+++ b/lib/redlock/supervisor.ex
@@ -6,6 +6,7 @@ defmodule Redlock.Supervisor do
   # default Connection options
   @default_pool_size 2
   @default_port 6379
+  @default_database nil
   @default_retry_interval_base 300
   @default_retry_interval_max 3_000
   @default_reconnection_interval_base 300
@@ -149,6 +150,7 @@ defmodule Redlock.Supervisor do
     host = Keyword.fetch!(opts, :host)
     port = Keyword.get(opts, :port, @default_port)
     auth = Keyword.get(opts, :auth, nil)
+    database = Keyword.get(opts, :database, @default_database)
 
     interval_base =
       Keyword.get(opts,
@@ -167,6 +169,7 @@ defmodule Redlock.Supervisor do
                       [[name:                       name,
                         host:                       host,
                         port:                       port,
+                        database:                   database,
                         auth:                       auth,
                         pool_name:                  pool_name,
                         reconnection_interval_base: interval_base,


### PR DESCRIPTION
Redix/Redis support specifying a number for a database to connect to which allows you to partition
your keys into different databases. This allows you to, for example, flush the keys for a sub-section
of your keys without effecting other keys. This change passes through the database provided in the config
if one is given and defaults to nil, which means Redix will use the default Redis database 0