### PR TITLE
Dialyzer and test fixes

### DIFF
--- a/lib/redlock/command.ex
+++ b/lib/redlock/command.ex
@@ -30,7 +30,7 @@ defmodule Redlock.Command do
   end
 
   def lock(redix, resource, value, ttl) do
-    case Redix.command(redix, ["SET", resource, value, "NX", "PX", ttl]) do
+    case Redix.command(redix, ["SET", resource, value, "NX", "PX", to_string(ttl)]) do
 
       {:ok, "OK"} -> :ok
 
@@ -45,7 +45,7 @@ defmodule Redlock.Command do
   end
 
   def unlock(redix, resource, value) do
-    Redix.command(redix, ["EVALSHA", helper_hash(), 1, resource, value])
+    Redix.command(redix, ["EVALSHA", helper_hash(), to_string(1), resource, value])
   end
 
   def authenticate(redix, pwd) do

--- a/lib/redlock/util.ex
+++ b/lib/redlock/util.ex
@@ -5,14 +5,17 @@ defmodule Redlock.Util do
   end
 
   def now() do
-    System.system_time(:milli_seconds)
+    System.system_time(:milliseconds)
   end
 
   def calc_backoff(base_ms, max_ms, attempt_counts) do
-    base_ms * :math.pow(2, attempt_counts)
-    |> min(max_ms)
-    |> trunc
-    |> :rand.uniform
+    max =
+      base_ms * :math.pow(2, attempt_counts)
+      |> min(max_ms)
+      |> trunc
+      |> max(base_ms + 1)
+
+    :rand.uniform(max - base_ms) + base_ms
   end
 
 end

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Redlock.Mixfile do
 
   defp deps do
     [
+      {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.15", only: :dev, runtime: false},
       {:redix, "~> 0.8.1"},
       {:poolboy, "~> 1.5"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_hash_ring": {:hex, :ex_hash_ring, "3.0.0", "da32c83d7c6d964b9537eb52f27bad0a3a6f7012efdc2749e11a5f268b120b6b", [:mix], [], "hexpm"},


### PR DESCRIPTION
This change:
* Adds dialyxer as a non-runtime dependency so that dialyzer tests can easily be run (using `mix dialyzer`)
* Fixes several incorrect types (which appear to have still worked but were causing dialyzer warnings)
* Modifies the backoff period calculation slightly - in its previous form it could potentially, for example, always randomly backoff by only 1ms. That would cause a failure in the unit tests.

There's still one dialyzer warning being reported, however, that in turn is caused by a typing error down in `ex_hash_ring`.