### PR TITLE
Avoid max.pow to overflow with values >= 1016

### DIFF
--- a/lib/redlock/util.ex
+++ b/lib/redlock/util.ex
@@ -1,5 +1,7 @@
 defmodule Redlock.Util do
 
+  @max_attempt_counts 1000
+
   def random_value() do
     SecureRandom.hex(40)
   end
@@ -9,8 +11,11 @@ defmodule Redlock.Util do
   end
 
   def calc_backoff(base_ms, max_ms, attempt_counts) do
+    # Avoid max.pow to overflow
+    safe_attempt_counts = min(@max_attempt_counts, attempt_counts)
+
     max =
-      base_ms * :math.pow(2, attempt_counts)
+      base_ms * :math.pow(2, safe_attempt_counts)
       |> min(max_ms)
       |> trunc
       |> max(base_ms + 1)

--- a/test/util_test.exs
+++ b/test/util_test.exs
@@ -1,0 +1,17 @@
+defmodule Redlock.UtilTest do
+
+  use ExUnit.Case
+
+  alias Redlock.Util
+
+  describe "calc_backoff/3" do
+    test "returns the backoff when the attemp_counts are high enough to overflow" do
+      base_ms = 300
+      max_ms = 3000
+      attempt_counts = 1016
+
+      assert is_number(Util.calc_backoff(base_ms, max_ms, attempt_counts))
+    end
+  end
+
+end


### PR DESCRIPTION
## Bug
When the Redis connection is not available, the connection keeper tries to reconnect. If the attemps reach 1016, the calc_backoff will overflow which makes the GenServer crash with a `ArithmeticError` error. 

This prints the stacktrace in the log or error tracer and leak the credentials that the GenServer has in memory in the `state`:

This will be logged:
```elixir
%Redlock.ConnectionKeeper{auth: "blabla", database: nil, host: "redis-bla", port: 6379, reconnection_attempts: 1016, reconnection_interval_base: 300, reconnection_interval_max: 3000, redix: nil, ssl: false}
```

## Solution
As the first solution (maybe not the best) the calc_backoff should be safe no matter the number of attempts it receives, so we avoid the process crashing.


Note: In the future it could be nice to hide the `auth` outside the `state` of the gen server, because other crashes will provoke the same problem, maybe fetching the secret from the application, with `get_env` could be a solution.