### PR TITLE
Add extend functionality to Redlock

### DIFF
--- a/lib/redlock.ex
+++ b/lib/redlock.ex
@@ -165,4 +165,8 @@ defmodule Redlock do
   def unlock(resource, value) do
     Redlock.Executor.unlock(resource, value)
   end
+
+  def extend(resource, value, ttl) do
+    Redlock.Executor.extend(resource, value, ttl)
+  end
 end

--- a/lib/redlock/command.ex
+++ b/lib/redlock/command.ex
@@ -1,7 +1,7 @@
 defmodule Redlock.Command do
   require Logger
 
-  @helper_script ~S"""
+  @unlock_script ~S"""
   if redis.call("get",KEYS[1]) == ARGV[1] then
     return redis.call("del",KEYS[1])
   else
@@ -9,21 +9,32 @@ defmodule Redlock.Command do
   end
   """
 
-  def helper_hash() do
-    :crypto.hash(:sha, @helper_script) |> Base.encode16() |> String.downcase()
+  @extend_script ~S"""
+  if redis.call("get",KEYS[1]) == ARGV[1] then
+    return redis.call("pexpire",KEYS[1],ARGV[2],"GT")
+  else
+    return redis.error_reply('NOT LOCKED')
+  end
+  """
+
+  def unlock_hash() do
+    :crypto.hash(:sha, @unlock_script) |> Base.encode16() |> String.downcase()
   end
 
-  def install_script(redix) do
-    case Redix.command(redix, ["SCRIPT", "LOAD", @helper_script]) do
-      {:ok, val} ->
-        if val == helper_hash() do
-          {:ok, val}
-        else
-          {:error, :hash_mismatch}
-        end
+  def extend_hash() do
+    :crypto.hash(:sha, @extend_script) |> Base.encode16() |> String.downcase()
+  end
 
-      other ->
-        other
+  def install_scripts(redix) do
+    with {:ok, unlock_val} <- Redix.command(redix, ["SCRIPT", "LOAD", @unlock_script]),
+         {:ok, extend_val} <- Redix.command(redix, ["SCRIPT", "LOAD", @extend_script]) do
+      if unlock_val == unlock_hash() and extend_val == extend_hash() do
+        {:ok, unlock_val, extend_val}
+      else
+        {:error, :hash_mismatch}
+      end
+    else
+      error -> error
     end
   end
 
@@ -43,6 +54,17 @@ defmodule Redlock.Command do
   end
 
   def unlock(redix, resource, value) do
-    Redix.command(redix, ["EVALSHA", helper_hash(), to_string(1), resource, value])
+    Redix.command(redix, ["EVALSHA", unlock_hash(), to_string(1), resource, value])
+  end
+
+  def extend(redix, resource, value, ttl) do
+    case Redix.command(redix, ["EVALSHA", extend_hash(), to_string(1), resource, value, ttl]) do
+      {:ok, _} ->
+        :ok
+
+      other ->
+        Logger.info("<Redlock> Unable to extend resource: #{resource}. #{inspect(other)}")
+        {:error, :cannot_extend}
+    end
   end
 end

--- a/lib/redlock/connection_keeper.ex
+++ b/lib/redlock/connection_keeper.ex
@@ -59,7 +59,7 @@ defmodule Redlock.ConnectionKeeper do
           Logger.debug("<Redlock.ConnectionKeeper:#{host}:#{port}> connected to Redis")
         end
 
-        with :ok <- install_script(pid, state) do
+        with :ok <- install_scripts(pid, state) do
           {:noreply, %{state | redix: pid, reconnection_attempts: 0}}
         else
           :error ->
@@ -145,14 +145,14 @@ defmodule Redlock.ConnectionKeeper do
     )
   end
 
-  defp install_script(pid, %{host: host, port: port}) do
-    case Redlock.Command.install_script(pid) do
-      {:ok, _val} ->
+  defp install_scripts(pid, %{host: host, port: port}) do
+    case Redlock.Command.install_scripts(pid) do
+      {:ok, _unlock_val, _extend_val} ->
         :ok
 
       other ->
         Logger.warn(
-          "<Redlock:ConnectionKeeper:#{host}:#{port}> failed to install script: #{inspect(other)}"
+          "<Redlock:ConnectionKeeper:#{host}:#{port}> failed to install scripts: #{inspect(other)}"
         )
 
         :error

--- a/lib/redlock/executor.ex
+++ b/lib/redlock/executor.ex
@@ -33,6 +33,10 @@ defmodule Redlock.Executor do
     end)
   end
 
+  def extend(resource, value, ttl) do
+    do_extend(resource, value, ttl, FastGlobal.get(:redlock_conf))
+  end
+
   defp do_lock(resource, _ttl, _value, retry, %{max_retry: max_retry})
        when retry >= max_retry do
     Logger.warn("<Redlock> failed to lock resource eventually: #{resource}")
@@ -40,6 +44,41 @@ defmodule Redlock.Executor do
   end
 
   defp do_lock(resource, ttl, value, attempts, config) do
+    {number_of_success, quorum, validity} =
+      lock_helper("lock", &lock_on_node/4, resource, value, ttl, config)
+
+    if number_of_success >= quorum and validity > 0 do
+      debug_log(
+        config.show_debug_logs,
+        "<Redlock> created lock for '#{resource}' successfully"
+      )
+
+      {:ok, value}
+    else
+      Logger.info("<Redlock> failed to lock '#{resource}', retry after interval")
+      calc_backoff(config, attempts) |> Process.sleep()
+      do_lock(resource, ttl, value, attempts + 1, config)
+    end
+  end
+
+  def do_extend(resource, value, ttl, config) do
+    {number_of_success, quorum, validity} =
+      lock_helper("extend", &extend_on_node/4, resource, value, ttl, config)
+
+    if number_of_success >= quorum and validity > 0 do
+      debug_log(
+        config.show_debug_logs,
+        "<Redlock> extended lock for '#{resource}' successfully"
+      )
+
+      :ok
+    else
+      Logger.warn("<Redlock> failed to extend lock resource: #{resource}")
+      :error
+    end
+  end
+
+  defp lock_helper(action, callback, resource, value, ttl, config) do
     started_at = now()
     servers = NodeChooser.choose(resource)
     quorum = div(length(servers), 2) + 1
@@ -47,11 +86,11 @@ defmodule Redlock.Executor do
     results =
       servers
       |> Enum.map(fn node ->
-        case lock_on_node(node, resource, value, ttl * 1000) do
+        case callback.(node, resource, value, ttl * 1000) do
           :ok ->
             debug_log(
               config.show_debug_logs,
-              "<Redlock> locked '#{resource}' successfully on node: #{node}"
+              "<Redlock> #{action}ed '#{resource}' successfully on node: #{node}, ttl: #{ttl}"
             )
 
             true
@@ -72,18 +111,7 @@ defmodule Redlock.Executor do
       "<Redlock> elapsed-#{elapsed_time} : success-#{number_of_success} : quorum-#{quorum}"
     )
 
-    if number_of_success >= quorum and validity > 0 do
-      debug_log(
-        config.show_debug_logs,
-        "<Redlock> created lock for '#{resource}' successfully"
-      )
-
-      {:ok, value}
-    else
-      Logger.info("<Redlock> failed to lock '#{resource}', retry after interval")
-      calc_backoff(config, attempts) |> Process.sleep()
-      do_lock(resource, ttl, value, attempts + 1, config)
-    end
+    {number_of_success, quorum, validity}
   end
 
   defp calc_backoff(config, attempts) do
@@ -112,6 +140,19 @@ defmodule Redlock.Executor do
       case ConnectionKeeper.connection(conn_keeper) do
         {:ok, redix} ->
           Command.unlock(redix, resource, value)
+
+        {:error, :not_found} = error ->
+          Logger.warn("<Redlock> connection is currently unavailable")
+          error
+      end
+    end)
+  end
+
+  def extend_on_node(node, resource, value, ttl) do
+    :poolboy.transaction(node, fn conn_keeper ->
+      case ConnectionKeeper.connection(conn_keeper) do
+        {:ok, redix} ->
+          Command.extend(redix, resource, value, ttl)
 
         {:error, :not_found} = error ->
           Logger.warn("<Redlock> connection is currently unavailable")

--- a/test/redlock_test.exs
+++ b/test/redlock_test.exs
@@ -53,4 +53,28 @@ defmodule RedlockTest do
     # should success eventually
     assert result1 == {:ok, 2}
   end
+
+  test "extend" do
+    key = "baz"
+
+    # this lock automatically expired in 1 seconds.
+    {:ok, mutex} = Redlock.lock(key, 1)
+
+    # extend the lock to 20 seconds
+    assert Redlock.extend(key, mutex, 20) == :ok
+
+    # try to lock, and do some retry internally.
+    result1 =
+      Redlock.transaction(key, 5, fn ->
+        {:ok, 2}
+      end)
+
+    # should fail eventually after retries give up
+    assert result1 == {:error, :lock_failure}
+  end
+
+  test "extend failure" do
+    # extending a lock that is not held should fail
+    assert Redlock.extend("not-locked", "not-mutex", 10) == :error
+  end
 end


### PR DESCRIPTION
Add the ability for the client to extend a lock's TTL. This is useful in situations where a client needs to lock a resource for a long time but still wants a relatively shorter TTL in case the lock-holder crashes or exits unexpectedly. The lock-holder can continually extend its ownership of the lock while it still needs it.

The changes consist of adding a new "extend" Lua script similar to the existing "unlock" script. This will check if the caller is holding the lock and set a new expiry if the new expiry is larger than the existing one. If it's not currently holding the lock, an error will be returned to the user. In this case, it does not make sense to retry extending a lock that you're not already holding.

I tested the new functionality manually and added unit tests to further test this functionality.