### PR TITLE
Allow passing socket opts + improve retry logic

### DIFF
--- a/lib/redlock/connection_keeper.ex
+++ b/lib/redlock/connection_keeper.ex
@@ -2,6 +2,7 @@ defmodule Redlock.ConnectionKeeper do
   @default_port 6379
   @default_database nil
   @default_ssl false
+  @default_socket_opts []
   @default_reconnection_interval_base 500
   @default_reconnection_interval_max 5_000
 
@@ -20,6 +21,7 @@ defmodule Redlock.ConnectionKeeper do
             database: nil,
             redix: nil,
             auth: nil,
+            socket_opts: nil,
             reconnection_interval_base: 0,
             reconnection_interval_max: 0,
             reconnection_attempts: 0
@@ -42,6 +44,7 @@ defmodule Redlock.ConnectionKeeper do
           ssl: ssl,
           auth: auth,
           database: database,
+          socket_opts: socket_opts,
           reconnection_attempts: attempts
         } = state
       ) do
@@ -51,6 +54,7 @@ defmodule Redlock.ConnectionKeeper do
            ssl: ssl,
            database: database,
            password: auth,
+           socket_opts: socket_opts,
            sync_connect: true,
            exit_on_disconnection: true
          ) do
@@ -109,6 +113,7 @@ defmodule Redlock.ConnectionKeeper do
     database = Keyword.get(opts, :database, @default_database)
     auth = Keyword.get(opts, :auth)
     ssl = Keyword.get(opts, :ssl, @default_ssl)
+    socket_opts = Keyword.get(opts, :socket_opts, @default_socket_opts)
 
     reconnection_interval_base =
       Keyword.get(
@@ -130,6 +135,7 @@ defmodule Redlock.ConnectionKeeper do
       ssl: ssl,
       database: database,
       auth: auth,
+      socket_opts: socket_opts,
       redix: nil,
       reconnection_attempts: 0,
       reconnection_interval_base: reconnection_interval_base,

--- a/lib/redlock/node_supervisor.ex
+++ b/lib/redlock/node_supervisor.ex
@@ -25,15 +25,38 @@ defmodule Redlock.NodeSupervisor do
     ssl = Keyword.fetch!(opts, :ssl)
     database = Keyword.fetch!(opts, :database)
     auth = Keyword.fetch!(opts, :auth)
+    socket_opts = Keyword.fetch!(opts, :socket_opts)
     interval_base = Keyword.fetch!(opts, :reconnection_interval_base)
     interval_max = Keyword.fetch!(opts, :reconnection_interval_max)
     size = Keyword.fetch!(opts, :pool_size)
 
-    children(name, host, port, ssl, database, auth, interval_base, interval_max, size)
+    children(
+      name,
+      host,
+      port,
+      ssl,
+      database,
+      auth,
+      socket_opts,
+      interval_base,
+      interval_max,
+      size
+    )
     |> Supervisor.init(strategy: :one_for_one)
   end
 
-  defp children(name, host, port, ssl, database, auth, interval_base, interval_max, size) do
+  defp children(
+         name,
+         host,
+         port,
+         ssl,
+         database,
+         auth,
+         socket_opts,
+         interval_base,
+         interval_max,
+         size
+       ) do
     [
       :poolboy.child_spec(
         name,
@@ -43,6 +66,7 @@ defmodule Redlock.NodeSupervisor do
         ssl: ssl,
         database: database,
         auth: auth,
+        socket_opts: socket_opts,
         reconnection_interval_base: interval_base,
         reconnection_interval_max: interval_max
       )

--- a/lib/redlock/supervisor.ex
+++ b/lib/redlock/supervisor.ex
@@ -7,6 +7,7 @@ defmodule Redlock.Supervisor do
   @default_port 6379
   @default_ssl false
   @default_database nil
+  @default_socket_opts []
   @default_retry_interval_base 300
   @default_retry_interval_max 3_000
   @default_reconnection_interval_base 300
@@ -148,6 +149,7 @@ defmodule Redlock.Supervisor do
     ssl = Keyword.get(opts, :ssl, @default_ssl)
     auth = Keyword.get(opts, :auth, nil)
     database = Keyword.get(opts, :database, @default_database)
+    socket_opts = Keyword.get(opts, :socket_opts, @default_socket_opts)
 
     interval_base =
       Keyword.get(
@@ -175,6 +177,7 @@ defmodule Redlock.Supervisor do
         ssl: ssl,
         database: database,
         auth: auth,
+        socket_opts: socket_opts,
         pool_name: pool_name,
         reconnection_interval_base: interval_base,
         reconnection_interval_max: interval_max,


### PR DESCRIPTION
Hi @lyokato , could you look at the following improvements?

This commit does two things:

1. Allow passing of socket_opts into the underlying Redix library. This is necessary for passing options that will be used by the SSL socket, like certificates. This is especially useful for some servers such as Amazon's ElastiCache. See more info in the Redix docs here: https://hexdocs.pm/redix/Redix.html#module-ssl

2. The existing retry mechanism has a couple issues. The first is that setting retry config to zero would cause it to never lock at all. The behaviour with zero retries should be that it tries once and immediately passes a failure to the user if it could not acquire the lock. The second issue is that after all retries have been used up, it would only pass a failure back to the user after the process has slept for a while. It should instead pass the failure back to the user immediately after the last retry has failed. The user should know the lock failed as soon as possible. This code should fix both issues.