### PR TITLE
Remove SecureRandom dependency

### DIFF
--- a/lib/redlock/util.ex
+++ b/lib/redlock/util.ex
@@ -2,7 +2,8 @@ defmodule Redlock.Util do
   @max_attempt_counts 1000
 
   def random_value() do
-    SecureRandom.hex(40)
+    bytes = :crypto.strong_rand_bytes(40)
+    Base.encode16(bytes, case: :lower)
   end
 
   def now() do

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Redlock.Mixfile do
 
   def application do
     [
-      extra_applications: [:logger, :secure_random, :redix, :poolboy, :ex_hash_ring]
+      extra_applications: [:logger, :redix, :poolboy, :ex_hash_ring]
     ]
   end
 
@@ -28,8 +28,7 @@ defmodule Redlock.Mixfile do
       {:redix, "~> 1.2"},
       {:poolboy, "~> 1.5"},
       {:fastglobal, "~> 1.0.0"},
-      {:ex_hash_ring, "~> 3.0"},
-      {:secure_random, "~> 0.5.1"}
+      {:ex_hash_ring, "~> 3.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -11,6 +11,5 @@
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "poolboy": {:hex, :poolboy, "1.5.2", "392b007a1693a64540cead79830443abf5762f5d30cf50bc95cb2c1aaafa006b", [:rebar3], [], "hexpm", "dad79704ce5440f3d5a3681c8590b9dc25d1a561e8f5a9c995281012860901e3"},
   "redix": {:hex, :redix, "1.2.1", "edf7392c0fa08708f5869e301aad20445f72ebc1949ea1c2496eaf344c845a0d", [:mix], [{:castore, "~> 0.1.0 or ~> 1.0", [hex: :castore, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "62608edd20a47b458a30737fd734e6f73d1f1665f3ca7821c1ee8f9abc725f11"},
-  "secure_random": {:hex, :secure_random, "0.5.1", "c5532b37c89d175c328f5196a0c2a5680b15ebce3e654da37129a9fe40ebf51b", [:mix], [], "hexpm", "1b9754f15e3940a143baafd19da12293f100044df69ea12db5d72878312ae6ab"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
 }


### PR DESCRIPTION
This dependency has gone stale and is not active in removing the compiler warnings about `Bitwise` being deprecated. As an alternative simply using `:crypto` directly, `SecureRandom` is no longer necessary.

```
==> secure_random
Compiling 1 file (.ex)
    warning: use Bitwise is deprecated. import Bitwise instead
    │
  2 │   use Bitwise
    │   ~~~~~~~~~~~
    │
    └─ lib/secure_random.ex:2: SecureRandom (module)
```