### PR TITLE
Drop support for elixir 1.12 and 1.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-20.04"]
-        elixir: ["1.14"]
-        otp: ["25"]
+        elixir: ["1.16"]
+        otp: ["26"]
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
@@ -49,11 +49,8 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        elixir: ["1.14", "1.13", "1.12"]
-        otp: ["25", "24", "23"]
-        exclude:
-          - elixir: "1.12"
-            otp: "25"
+        elixir: ["1.16", "1.15", "1.14"]
+        otp: ["26", "25", "24"]
     steps:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Redlock.Mixfile do
   def project do
     [
       app: :redlock,
-      elixir: "~> 1.12",
+      elixir: "~> 1.14",
       version: @version,
       package: package(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
We are on version 1.16 and should support only the latest three releases along with the latest 3 OTP releases.