### PR TITLE
Add default database - redix 1.3.0 - nimble_options 1.0 compatibility

### DIFF
--- a/lib/redlock/connection_keeper.ex
+++ b/lib/redlock/connection_keeper.ex
@@ -1,6 +1,6 @@
 defmodule Redlock.ConnectionKeeper do
   @default_port 6379
-  @default_database nil
+  @default_database 0
   @default_ssl false
   @default_socket_opts []
   @default_reconnection_interval_base 500

--- a/lib/redlock/supervisor.ex
+++ b/lib/redlock/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Redlock.Supervisor do
   @default_pool_size 2
   @default_port 6379
   @default_ssl false
-  @default_database nil
+  @default_database 0
   @default_socket_opts []
   @default_retry_interval_base 300
   @default_retry_interval_max 3_000


### PR DESCRIPTION
## Problem

After updating to redix 1.3.0 with nimble_options 1.0, this library fails with the current defaults. Specifically the `@default_database: nil` contant.

```
"GenServer #PID<0.17129.0> terminating
** (NimbleOptions.ValidationError) expected :database option to match at least one given type, but didn't match any. Here are the reasons why it didn't match each of the allowed types:

  * invalid value for :database option: expected string, got: nil
  * invalid value for :database option: expected non negative integer, got: nil
    (nimble_options 0.5.2) lib/nimble_options.ex:334: NimbleOptions.validate!/2
    (redix 1.3.0) lib/redix/start_options.ex:239: Redix.StartOptions.sanitize/1
    (redix 1.3.0) lib/redix/connection.ex:27: Redix.Connection.start_link/1
    (redlock 1.0.18) lib/redlock/connection_keeper.ex:51: Redlock.ConnectionKeeper.handle_info/2
    (stdlib 5.2) gen_server.erl:1095: :gen_server.try_handle_info/3
    (stdlib 5.2) gen_server.erl:1183: :gen_server.handle_msg/6
    (stdlib 5.2) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```
## Solution

Set the default database to the Redis default database that is 0.